### PR TITLE
가격 범위 내 추천 상품이 0개 일 때 로직 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
- 0개 일 때 결과로 각종 method를 사용하는데 Error가 발생함 (없는 값에 method를 적용하기 때문)
- 0개 일 때 가격 범위를 -50000 ~ +50000 해서 새로운 배열을 만들어 해당 값을 반환
- 1,2개 일 때는 원래 가격범위 내에서 나온 결과와 가격범위를 넓혀서 나온 결과를 합쳐서 3개를 만들어 반환
- 우선적으로는 원래 가격범위 내에서 나온 상품의 순위를 높게 하고, 그 나머지 자리를 넓힌 가격범위에서 나온 상품을 넣었음

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 가격 범위 내 추천 상품이 0개 일 때 로직 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 0개 일 때 결과로 각종 method를 사용하는데 Error가 발생
- reduce를 사용할 때, 가격범위 내 반환상품이 없어 길이가 0인 경우 Error를 발생시킨다.
- 해결책으로 가격범위 내 상품이 0개 일 때의 경우를 switch문으로 분기처리

2. 1~2개 일 때 반환값 처리
- 기획 상 3개의 상품을 추천하도록 되어 있다.
- 원래의 가격범위에서 1~2개의 상품이 반환되었을 때, 가격범위를 -50000 ~ +50000 넓혀서 새로운 상품을 반환
- 새로운 상품에 splice 하여 원래 가격범위에서 반환된 상품의 배열길이 만큼만 남기고 잘라서 결과값에 push
- 해당 로직들을 swtich문으로 분기처리
- 3개를 채워서 결과를 반환하도록 로직 변경

3. 반환값에서의 우선순위
- 우선적으로는 원래 가격범위 내에서 나온 상품의 순위를 높게 하고, 그 나머지 자리를 넓힌 가격범위에서 나온 상품을 넣었음

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- if문에서 많은 분기처리보다는 swtich문을 사용하는 편이 더 가동성에 좋은 것 같음.
- 리팩토링 및 가독성에 대한 중요성을 깨닫게 됨 (내가 봐도 내 코드가 무슨 코드인지 바로 짐작이 가질 않음)

<br />

## :: 기타 질문 및 특이 사항
