### PR TITLE
선물 추천 비즈니스 로직 수정

### DIFF
--- a/src/suggest/suggest.service.ts
+++ b/src/suggest/suggest.service.ts
@@ -123,9 +123,7 @@ export class SuggestService {
           ...value,
         ]);
 
-        reviewSortResult = addResult
-          .sort((a, b) => b.product_review_count - a.product_review_count)
-          .splice(0, 3);
+        reviewSortResult = addResult.splice(0, 3);
 
         break;
       }
@@ -183,11 +181,9 @@ export class SuggestService {
           ...value,
         ]);
 
-        reviewSortResult = sortResult
-          .sort((a, b) => b.product_review_count - a.product_review_count)
-          .splice(0, 3);
-
         reviewSortResult.push(...addResult);
+
+        reviewSortResult = sortResult.splice(0, 3);
 
         break;
       }
@@ -203,11 +199,20 @@ export class SuggestService {
 
         const sortResult = result.reduce((acc, value) => [...acc, ...value]);
 
-        reviewSortResult = sortResult
-          .sort((a, b) => b.product_review_count - a.product_review_count)
-          .splice(0, 3);
+        const suggestMinLength = Math.ceil(0);
+        const suggestMaxLength = Math.floor(sortResult.length);
 
-        return reviewSortResult;
+        const randomProductResult = [];
+
+        for (let i = 0; i < 3; i++) {
+          const randomInteger =
+            Math.floor(
+              Math.random() * (suggestMaxLength - suggestMinLength + 1),
+            ) + suggestMinLength;
+          randomProductResult.push(sortResult[randomInteger]);
+        }
+
+        return randomProductResult;
       }
     }
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 선물 추천 비즈니스 로직 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 리뷰순 상품추천 로직 제거
- 기존 리뷰순으로 3개의 추천상품을 필터링하는 방식을 사용하면 유사한 상품군이 도출되었을 때 같은 상품들이 계속 추천될 확률이 높았음
- 그 말은 즉, 사람들이 대부분이 생각할 수 있는 상품들이 추천 될 확률이 높고 이것은 우리 서비스의 목적과는 맞지 않음.
- 기존 라벨링으로 필터링된 상품군을 먼저 도출하고, 이 상품군들 중 랜덤으로 상품 3가지를 추천해주는 방식으로 로직을 변경하였음
- 추가적으로 얻을 수 있는 효과로는 같은 라벨링을 선택하더라도 다른 상품들이 추천될 수 있는 효과를 가져올 수 있었음

2. 추가적으로 추천상품이 늘어날 때의 로직 변경
- 기존 로직은 추천상품이 1개 또는 2개일 때, splice로 길이를 3만 남기고 자르는 로직을 먼저 수행한 후, 추가적인 추천상품을 push하는 로직이었는데, 그렇게 되면 클라이언트에게 반환되는 결과값의 길이가 3이라는 보장이 없으므로, 먼저 push를 하고, splice를 이용해 길이를 3으로 만드는 로직으로 변경하였음

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

<br />

## :: 기타 질문 및 특이 사항
